### PR TITLE
Ignore formulas in XLRD

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -39,6 +39,7 @@ def open_workbook(filename=None,
                   formatting_info=False,
                   on_demand=False,
                   ragged_rows=False,
+                  data_only=True,
                   ignore_workbook_corruption=False
                   ):
     """
@@ -145,6 +146,7 @@ def open_workbook(filename=None,
                 formatting_info=formatting_info,
                 on_demand=on_demand,
                 ragged_rows=ragged_rows,
+                data_only=data_only,
             )
             return bk
         if 'xl/workbook.bin' in component_names:
@@ -165,6 +167,7 @@ def open_workbook(filename=None,
         on_demand=on_demand,
         ragged_rows=ragged_rows,
         ignore_workbook_corruption=ignore_workbook_corruption,
+        data_only=data_only,
     )
     return bk
 

--- a/xlrd/book.py
+++ b/xlrd/book.py
@@ -72,7 +72,8 @@ def open_workbook_xls(filename=None,
                       file_contents=None,
                       encoding_override=None,
                       formatting_info=False, on_demand=False, ragged_rows=False,
-                      ignore_workbook_corruption=False):
+                      ignore_workbook_corruption=False,
+                      data_only=True):
     t0 = perf_counter()
     if TOGGLE_GC:
         orig_gc_enabled = gc.isenabled()
@@ -87,6 +88,7 @@ def open_workbook_xls(filename=None,
             formatting_info=formatting_info,
             on_demand=on_demand,
             ragged_rows=ragged_rows,
+            data_only=data_only,
             ignore_workbook_corruption=ignore_workbook_corruption
         )
         t1 = perf_counter()
@@ -619,6 +621,7 @@ class Book(BaseObject):
                      formatting_info=False,
                      on_demand=False,
                      ragged_rows=False,
+                     data_only=True,
                      ignore_workbook_corruption=False
                      ):
         # DEBUG = 0
@@ -628,6 +631,7 @@ class Book(BaseObject):
         self.encoding_override = encoding_override
         self.formatting_info = formatting_info
         self.on_demand = on_demand
+        self.data_only = data_only
         self.ragged_rows = ragged_rows
 
         if not file_contents:

--- a/xlrd/sheet.py
+++ b/xlrd/sheet.py
@@ -328,6 +328,7 @@ class Sheet(BaseObject):
         self.verbosity = book.verbosity
         self.formatting_info = book.formatting_info
         self.ragged_rows = book.ragged_rows
+        self.data_only = book.data_only
         if self.ragged_rows:
             self.put_cell = self.put_cell_ragged
         else:
@@ -936,71 +937,72 @@ class Sheet(BaseObject):
                     rowx, colx, cell_attr,  result_str, flags = local_unpack('<HH3s8sB', data[0:16])
                     xf_index =  self.fixed_BIFF2_xfindex(cell_attr, rowx, colx)
 
-                # Ignore formulas; treat the cell as empty string (not empty).
-                self_put_cell(rowx, colx, XL_CELL_TEXT, "", xf_index)
-
-                # if blah_formulas: # testing formula dumper
-                #     #### XXXX FIXME
-                #     fprintf(self.logfile, "FORMULA: rowx=%d colx=%d\n", rowx, colx)
-                #     fmlalen = local_unpack("<H", data[20:22])[0]
-                #     decompile_formula(bk, data[22:], fmlalen, FMLA_TYPE_CELL,
-                #         browx=rowx, bcolx=colx, blah=1, r1c1=r1c1)
-                # if result_str[6:8] == b"\xFF\xFF":
-                #     first_byte = BYTES_ORD(result_str[0])
-                #     if first_byte == 0:
-                #         # need to read next record (STRING)
-                #         gotstring = 0
-                #         # if flags & 8:
-                #         if 1: # "flags & 8" applies only to SHRFMLA
-                #             # actually there's an optional SHRFMLA or ARRAY etc record to skip over
-                #             rc2, data2_len, data2 = bk.get_record_parts()
-                #             if rc2 == XL_STRING or rc2 == XL_STRING_B2:
-                #                 gotstring = 1
-                #             elif rc2 == XL_ARRAY:
-                #                 row1x, rownx, col1x, colnx, array_flags, tokslen = \
-                #                     local_unpack("<HHBBBxxxxxH", data2[:14])
-                #                 if blah_formulas:
-                #                     fprintf(self.logfile, "ARRAY: %d %d %d %d %d\n",
-                #                         row1x, rownx, col1x, colnx, array_flags)
-                #                     # dump_formula(bk, data2[14:], tokslen, bv, reldelta=0, blah=1)
-                #             elif rc2 == XL_SHRFMLA:
-                #                 row1x, rownx, col1x, colnx, nfmlas, tokslen = \
-                #                     local_unpack("<HHBBxBH", data2[:10])
-                #                 if blah_formulas:
-                #                     fprintf(self.logfile, "SHRFMLA (sub): %d %d %d %d %d\n",
-                #                         row1x, rownx, col1x, colnx, nfmlas)
-                #                     decompile_formula(bk, data2[10:], tokslen, FMLA_TYPE_SHARED,
-                #                         blah=1, browx=rowx, bcolx=colx, r1c1=r1c1)
-                #             elif rc2 not in XL_SHRFMLA_ETC_ETC:
-                #                 raise XLRDError(
-                #                     "Expected SHRFMLA, ARRAY, TABLEOP* or STRING record; found 0x%04x" % rc2)
-                #             # if DEBUG: print "gotstring:", gotstring
-                #         # now for the STRING record
-                #         if not gotstring:
-                #             rc2, _unused_len, data2 = bk.get_record_parts()
-                #             if rc2 not in (XL_STRING, XL_STRING_B2):
-                #                 raise XLRDError("Expected STRING record; found 0x%04x" % rc2)
-                #         # if DEBUG: print "STRING: data=%r BIFF=%d cp=%d" % (data2, self.biff_version, bk.encoding)
-                #         strg = self.string_record_contents(data2)
-                #         self.put_cell(rowx, colx, XL_CELL_TEXT, strg, xf_index)
-                #         # if DEBUG: print "FORMULA strg %r" % strg
-                #     elif first_byte == 1:
-                #         # boolean formula result
-                #         value = BYTES_ORD(result_str[2])
-                #         self_put_cell(rowx, colx, XL_CELL_BOOLEAN, value, xf_index)
-                #     elif first_byte == 2:
-                #         # Error in cell
-                #         value = BYTES_ORD(result_str[2])
-                #         self_put_cell(rowx, colx, XL_CELL_ERROR, value, xf_index)
-                #     elif first_byte == 3:
-                #         # empty ... i.e. empty (zero-length) string, NOT an empty cell.
-                #         self_put_cell(rowx, colx, XL_CELL_TEXT, "", xf_index)
-                #     else:
-                #         raise XLRDError("unexpected special case (0x%02x) in FORMULA" % first_byte)
-                # else:
-                #     # it is a number
-                #     d = local_unpack('<d', result_str)[0]
-                #     self_put_cell(rowx, colx, None, d, xf_index)
+                if self.data_only:
+                    # Ignore all formulas; treat formula cells as an empty string.
+                    self_put_cell(rowx, colx, XL_CELL_TEXT, "", xf_index)
+                else:
+                    if blah_formulas: # testing formula dumper
+                        #### XXXX FIXME
+                        fprintf(self.logfile, "FORMULA: rowx=%d colx=%d\n", rowx, colx)
+                        fmlalen = local_unpack("<H", data[20:22])[0]
+                        decompile_formula(bk, data[22:], fmlalen, FMLA_TYPE_CELL,
+                            browx=rowx, bcolx=colx, blah=1, r1c1=r1c1)
+                    if result_str[6:8] == b"\xFF\xFF":
+                        first_byte = BYTES_ORD(result_str[0])
+                        if first_byte == 0:
+                            # need to read next record (STRING)
+                            gotstring = 0
+                            # if flags & 8:
+                            if 1: # "flags & 8" applies only to SHRFMLA
+                                # actually there's an optional SHRFMLA or ARRAY etc record to skip over
+                                rc2, data2_len, data2 = bk.get_record_parts()
+                                if rc2 == XL_STRING or rc2 == XL_STRING_B2:
+                                    gotstring = 1
+                                elif rc2 == XL_ARRAY:
+                                    row1x, rownx, col1x, colnx, array_flags, tokslen = \
+                                        local_unpack("<HHBBBxxxxxH", data2[:14])
+                                    if blah_formulas:
+                                        fprintf(self.logfile, "ARRAY: %d %d %d %d %d\n",
+                                            row1x, rownx, col1x, colnx, array_flags)
+                                        # dump_formula(bk, data2[14:], tokslen, bv, reldelta=0, blah=1)
+                                elif rc2 == XL_SHRFMLA:
+                                    row1x, rownx, col1x, colnx, nfmlas, tokslen = \
+                                        local_unpack("<HHBBxBH", data2[:10])
+                                    if blah_formulas:
+                                        fprintf(self.logfile, "SHRFMLA (sub): %d %d %d %d %d\n",
+                                            row1x, rownx, col1x, colnx, nfmlas)
+                                        decompile_formula(bk, data2[10:], tokslen, FMLA_TYPE_SHARED,
+                                            blah=1, browx=rowx, bcolx=colx, r1c1=r1c1)
+                                elif rc2 not in XL_SHRFMLA_ETC_ETC:
+                                    raise XLRDError(
+                                        "Expected SHRFMLA, ARRAY, TABLEOP* or STRING record; found 0x%04x" % rc2)
+                                # if DEBUG: print "gotstring:", gotstring
+                            # now for the STRING record
+                            if not gotstring:
+                                rc2, _unused_len, data2 = bk.get_record_parts()
+                                if rc2 not in (XL_STRING, XL_STRING_B2):
+                                    raise XLRDError("Expected STRING record; found 0x%04x" % rc2)
+                            # if DEBUG: print "STRING: data=%r BIFF=%d cp=%d" % (data2, self.biff_version, bk.encoding)
+                            strg = self.string_record_contents(data2)
+                            self.put_cell(rowx, colx, XL_CELL_TEXT, strg, xf_index)
+                            # if DEBUG: print "FORMULA strg %r" % strg
+                        elif first_byte == 1:
+                            # boolean formula result
+                            value = BYTES_ORD(result_str[2])
+                            self_put_cell(rowx, colx, XL_CELL_BOOLEAN, value, xf_index)
+                        elif first_byte == 2:
+                            # Error in cell
+                            value = BYTES_ORD(result_str[2])
+                            self_put_cell(rowx, colx, XL_CELL_ERROR, value, xf_index)
+                        elif first_byte == 3:
+                            # empty ... i.e. empty (zero-length) string, NOT an empty cell.
+                            self_put_cell(rowx, colx, XL_CELL_TEXT, "", xf_index)
+                        else:
+                            raise XLRDError("unexpected special case (0x%02x) in FORMULA" % first_byte)
+                    else:
+                        # it is a number
+                        d = local_unpack('<d', result_str)[0]
+                        self_put_cell(rowx, colx, None, d, xf_index)
             elif rc == XL_BOOLERR:
                 rowx, colx, xf_index, value, is_err = local_unpack('<HHHBB', data[:8])
                 # Note OOo Calc 2.0 writes 9-byte BOOLERR records.

--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -789,7 +789,8 @@ def open_workbook_2007_xml(zf,
                            use_mmap=0,
                            formatting_info=0,
                            on_demand=0,
-                           ragged_rows=0):
+                           ragged_rows=0,
+                           data_only=1):
     ensure_elementtree_imported(verbosity, logfile)
     bk = Book()
     bk.logfile = logfile
@@ -799,6 +800,7 @@ def open_workbook_2007_xml(zf,
         raise NotImplementedError("formatting_info=True not yet implemented")
     bk.use_mmap = False #### Not supported initially
     bk.on_demand = on_demand
+    bk.data_only = data_only
     if on_demand:
         if verbosity:
             print("WARNING *** on_demand=True not yet implemented; falling back to False", file=bk.logfile)


### PR DESCRIPTION
Introduces a new `data_only` parameter which, if set, will ignore any formulas in a spreadsheet and set their cells to an empty string (`""`) instead.